### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ Mikutap extension for Visual Studio Code
 
 ## Requirement
 
-**VS Code for Windows 自 1.31.0 起自带完整的 ffmpeg 动态链接库，无需替换；macOS 与 Linux 平台仍需替换**
-
 [VS Code 使用的 Electron 版本不包含 ffmpeg](https://stackoverflow.com/a/51735036)，需替换自带的 ffmpeg 动态链接库才能正常播放 (每次更新 VS Code 都需重新替换)
+
+*VS Code for Windows 1.31.0 - 1.35.1 不需替换，1.36.0 后无此待遇*
 
 <details><summary>
 <b>Manual Replacement</b>


### PR DESCRIPTION
我使用Windows1.42.1版本的VSCode，安装插件无法正常播放声音，替换对应Electron版本6.1.6中的ffmpeg.dll后可以正常播放声音。
根据https://github.com/nondanee/vsc-netease-music 目前的README，1.36.0及以后的Windows版本VSCode使用的Electron不再包含FFmpeg。