### PR TITLE
fix: extensionKind should be "ui"

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,5 +37,8 @@
 	},
 	"dependencies": {
 		"ws": "^7.4.6"
-	}
+	},
+	"extensionKind": [
+		"ui"
+	]
 }


### PR DESCRIPTION
extensionKind should be "ui" so we can use the ext on remote SSH without installing it on the remote side.